### PR TITLE
Task 0: Add end-to-end tests for App

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit.version>4.12</junit.version>
+    <jackson.version>2.7.0</jackson.version>
   </properties>
 
   <dependencies>
@@ -20,13 +22,28 @@
       <artifactId>flink-streaming-java_2.10</artifactId>
       <version>1.2.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
 
+    <!-- test dependencies -->
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-test-utils_2.10</artifactId>
+      <version>1.2.1</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>${junit.version}</version>
+      <type>jar</type>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/dataartisans/App.java
+++ b/src/main/java/com/dataartisans/App.java
@@ -2,6 +2,9 @@ package com.dataartisans;
 
 import com.dataartisans.provided.Event;
 import com.dataartisans.provided.EventGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -11,14 +14,62 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 public class App {
+    private static final String INPUT_PATH_PARAM = "inputPath";
+    private static final String OUTPUT_PATH_PARAM = "outputPath";
+
     public static void main( String[] args ) throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final ParameterTool params = ParameterTool.fromArgs(args);
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
-        DataStream<Event> eventStream = env.addSource(new EventGenerator());
+        DataStream<Event> eventStream = getStreamFromSource(env, params);
+
         eventStream.transform("OrderOperator", eventStream.getType(), new OrderOperator<>());
 
+        setStreamSink(eventStream, params);
+
         env.execute("Run Stream smoother");
+    }
+
+    private static DataStream<Event> getStreamFromSource(StreamExecutionEnvironment env, ParameterTool appConfig) {
+        if(appConfig.has(INPUT_PATH_PARAM)) {
+            return env.readTextFile(appConfig.get(INPUT_PATH_PARAM)).map(new JsonToEventMapper());
+        }
+        return env.addSource(new EventGenerator());
+    }
+    
+    private static void setStreamSink(DataStream<Event> stream, ParameterTool appConfig) {
+        if(appConfig.has(OUTPUT_PATH_PARAM)) {
+            stream.map(new EventToJsonMapper())
+                    .writeAsText(appConfig.get(OUTPUT_PATH_PARAM));
+        } else {
+            stream.print();
+        }
+    }
+
+    public static class JsonToEventMapper implements MapFunction<String, Event> {
+        private transient ObjectMapper jsonMapper;
+
+        @Override
+        public Event map(String value) throws Exception {
+            if (jsonMapper == null) {
+                jsonMapper = new ObjectMapper();
+            }
+            return jsonMapper.readValue(value, Event.class);
+        }
+    }
+
+    public static class EventToJsonMapper implements MapFunction<Event, String> {
+        private transient ObjectMapper jsonMapper;
+
+        @Override
+        public String map(Event value) throws Exception {
+            if (jsonMapper == null) {
+                jsonMapper = new ObjectMapper();
+            }
+            return jsonMapper.writeValueAsString(value);
+        }
     }
 
     private static class OrderOperator<T> extends AbstractStreamOperator<T> implements OneInputStreamOperator<T, T> {

--- a/src/main/java/com/dataartisans/App.java
+++ b/src/main/java/com/dataartisans/App.java
@@ -49,25 +49,19 @@ public class App {
     }
 
     public static class JsonToEventMapper implements MapFunction<String, Event> {
-        private transient ObjectMapper jsonMapper;
+        private static final ObjectMapper jsonMapper = new ObjectMapper();
 
         @Override
         public Event map(String value) throws Exception {
-            if (jsonMapper == null) {
-                jsonMapper = new ObjectMapper();
-            }
             return jsonMapper.readValue(value, Event.class);
         }
     }
 
     public static class EventToJsonMapper implements MapFunction<Event, String> {
-        private transient ObjectMapper jsonMapper;
+        private static final ObjectMapper jsonMapper = new ObjectMapper();
 
         @Override
         public String map(Event value) throws Exception {
-            if (jsonMapper == null) {
-                jsonMapper = new ObjectMapper();
-            }
             return jsonMapper.writeValueAsString(value);
         }
     }

--- a/src/main/java/com/dataartisans/provided/Event.java
+++ b/src/main/java/com/dataartisans/provided/Event.java
@@ -1,15 +1,36 @@
 package com.dataartisans.provided;
 
-/**
- * NOTE: Everything in the "provided" package IS NOT representative for
- * the level of quality we are expecting for the coding task submission.
- */
 public class Event {
   public long time;
   public String someData;
 
+  public Event() {}
+
+  public Event(long time, String someData) {
+    this.time = time;
+    this.someData = someData;
+  }
+
   @Override
   public String toString() {
-    return "Event(" + time + ", " + someData + ')';
+    return String.format("Event(%d, %s)", time, someData);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Event event = (Event) o;
+
+    if (time != event.time) return false;
+    return someData != null ? someData.equals(event.someData) : event.someData == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (time ^ (time >>> 32));
+    result = 31 * result + (someData != null ? someData.hashCode() : 0);
+    return result;
   }
 }

--- a/src/test/java/com/dataartisans/AppData.java
+++ b/src/test/java/com/dataartisans/AppData.java
@@ -1,0 +1,6 @@
+package com.dataartisans;
+
+public class AppData {
+    public static final String EVENT_STREAM_AS_LINEWISE_JSON = ""
+            + "{\"time\":1498404088692,\"someData\":\"some data value\"}";
+}

--- a/src/test/java/com/dataartisans/AppTest.java
+++ b/src/test/java/com/dataartisans/AppTest.java
@@ -1,38 +1,30 @@
 package com.dataartisans;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.apache.flink.streaming.util.StreamingProgramTestBase;
 
 /**
- * Unit test for simple App.
+ * {@link App} program should execute successfully.
  */
-public class AppTest 
-    extends TestCase
+public class AppTest extends StreamingProgramTestBase
 {
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public AppTest( String testName )
-    {
-        super( testName );
+    private String inputPath;
+    private String outputPath;
+
+    @Override
+    protected void preSubmit() throws Exception {
+        inputPath = createTempFile("AppTest_Input.txt", AppData.EVENT_STREAM_AS_LINEWISE_JSON);
+        outputPath = getTempDirPath("AppTest_Output");
     }
 
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite()
-    {
-        return new TestSuite( AppTest.class );
+    @Override
+    protected void postSubmit() throws Exception {
+        compareResultsByLinesInMemory(AppData.EVENT_STREAM_AS_LINEWISE_JSON, outputPath);
     }
 
-    /**
-     * Rigourous Test :-)
-     */
-    public void testApp()
-    {
-        assertTrue( true );
+    @Override
+    protected void testProgram() throws Exception {
+        App.main(new String[]{
+                "--inputPath", inputPath,
+                "--outputPath", outputPath});
     }
 }

--- a/src/test/java/com/dataartisans/EventToJsonMapperTests.java
+++ b/src/test/java/com/dataartisans/EventToJsonMapperTests.java
@@ -1,0 +1,23 @@
+package com.dataartisans;
+
+import com.dataartisans.provided.Event;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+
+public class EventToJsonMapperTests {
+    @Test
+    public void shouldSerializeEventToJson() {
+        Event anEvent = new Event(1498404088692L, "some data value");
+        String result = null;
+
+        try {
+            result = new App.EventToJsonMapper().map(anEvent);
+        } catch (Exception e) {
+            fail(e.toString());
+        }
+
+        assertEquals("should be a JSON string with matching values", "{\"time\":1498404088692,\"someData\":\"some data value\"}", result);
+    }
+}

--- a/src/test/java/com/dataartisans/JsonToEventMapperTests.java
+++ b/src/test/java/com/dataartisans/JsonToEventMapperTests.java
@@ -1,0 +1,23 @@
+package com.dataartisans;
+
+import com.dataartisans.provided.Event;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class JsonToEventMapperTests {
+    @Test
+    public void shouldParseSuccessfully() {
+        String validJsonString = "{\"time\":1498404088692,\"someData\":\"some data value\"}";
+        Event result = null;
+
+        try {
+            result = new App.JsonToEventMapper().map(validJsonString);
+        } catch (Exception e) {
+            fail(e.toString());
+        }
+
+        assertEquals("should be an Event object with matching values", new Event(1498404088692L, "some data value"), result);
+    }
+}

--- a/src/test/java/com/dataartisans/JsonToEventMapperTests.java
+++ b/src/test/java/com/dataartisans/JsonToEventMapperTests.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.fail;
 
 public class JsonToEventMapperTests {
     @Test
-    public void shouldParseSuccessfully() {
+    public void shouldParseJsonStringToEventObject() {
         String validJsonString = "{\"time\":1498404088692,\"someData\":\"some data value\"}";
         Event result = null;
 


### PR DESCRIPTION
Start by adding end-to-end tests for App. These tests will help us guide future tasks.

Approach:
* Inherit from `StreamingProgramTestBase`
* Add parameter based configuration to `App` to allow sourcing from and sinking to a file, for use in end-to-end tests
* Use linewise JSON as the file format, to avoid having to do tedious string parsing